### PR TITLE
Add webserver and single-page modes

### DIFF
--- a/Sources/SimpleSwiftServer/main.swift
+++ b/Sources/SimpleSwiftServer/main.swift
@@ -19,6 +19,8 @@ struct Server: ParsableCommand {
     enum Mode: String, EnumerableFlag {
         case directoryBrowser = "browse"
         case fileDownload = "file"
+        case webServer = "webserver"
+        case HTMLFile = "html"
 
         static func name(for value: Server.Mode) -> NameSpecification {
             return .customLong(value.rawValue)
@@ -50,6 +52,16 @@ struct Server: ParsableCommand {
             }
             server["/"] = { _ in
                 return .movedTemporarily("file/")
+            }
+        case .webServer:
+            server["/web/:path"] = shareFilesFromDirectory(path)
+            server["/"] = { _ in
+                return .movedTemporarily("web/")
+            }
+        case .HTMLFile:
+            server["/page/"] = shareFile(path)
+            server["/"] = { _ in
+                return .movedTemporarily("page/")
             }
         }
 


### PR DESCRIPTION
This PR adds "webserver" and "single-page" modes, addressing issue #2 .

The "webserver" doesn't execute any server-side files like PHP or Python, but files can reference each other and CSS and JS work fine.
The "single-page" mode hosts a single page. Some files are downloaded, some are rendered, and some are partially rendered. I recommend it to host HTML pages.

What would still be nice? A chatroom