### PR TITLE
Fix building on Linux

### DIFF
--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -20,4 +20,10 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
       - run: swift --version
+      - name: Patch Swifter
+        run: |
+          swift package edit Swifter
+          cd Packages/Swifter
+          git apply ../../swifter.patch
+          cd ../..
       - run: swift build

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -20,10 +20,4 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
       - run: swift --version
-      - name: Patch Swifter
-        run: |
-          swift package edit Swifter
-          cd Packages/Swifter
-          git apply ../../swifter.patch
-          cd ../..
       - run: swift build

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -40,7 +40,7 @@ jobs:
             swift: "5.0"
           - os: ubuntu-18.04
             swift: "5.1"
-          - os: ubuntu-18.latest
+          - os: ubuntu-latest
             swift: "4.2"
           - os: ubuntu-latest
             swift: "5.0"

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -1,0 +1,23 @@
+name: Push (non-master)
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  test:
+    name: Test Swift ${{ matrix.swift }}.x on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
+        swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - run: swift --version
+      - run: swift build

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -13,6 +13,39 @@ jobs:
       matrix:
         os: [macos-10.15, macos-latest, ubuntu-18.04, ubuntu-latest]
         swift: ["4.2", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
+        exclude:
+          - os: macos-10.15
+            swift: "4.2"
+          - os: macos-10.15
+            swift: "5.0"
+          - os: macos-10.15
+            swift: "5.1"
+          - os: macos-10.15
+            swift: "5.2"
+          - os: macos-latest
+            swift: "4.2"
+          - os: macos-latest
+            swift: "5.0"
+          - os: macos-latest
+            swift: "5.1"
+          - os: macos-latest
+            swift: "5.2"
+          - os: macos-latest
+            swift: "5.3"
+          - os: macos-latest
+            swift: "5.4"
+          - os: ubuntu-18.04
+            swift: "4.2"
+          - os: ubuntu-18.04
+            swift: "5.0"
+          - os: ubuntu-18.04
+            swift: "5.1"
+          - os: ubuntu-18.latest
+            swift: "4.2"
+          - os: ubuntu-latest
+            swift: "5.0"
+          - os: ubuntu-latest
+            swift: "5.1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "SwiftIP",
         "repositoryURL": "https://github.com/Samasaur1/SwiftIP",
         "state": {
-          "branch": "fix-linux",
-          "revision": "0fb20b38f3edb9f77ce31c76ba3ba7c112eed08c",
-          "version": null
+          "branch": null,
+          "revision": "a10b6ee21d2f9bdf3c992211905c6b2f67eddee6",
+          "version": "2.2.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -12,11 +12,11 @@
       },
       {
         "package": "Swifter",
-        "repositoryURL": "https://github.com/httpswift/swifter",
+        "repositoryURL": "https://github.com/Samasaur1/swifter",
         "state": {
-          "branch": null,
-          "revision": "f76bf391e127333a371e45c4e75f52f71cfd144f",
-          "version": "1.4.5"
+          "branch": "simpleswiftserver-version",
+          "revision": "0b562dddf2654efa50d42a99923e919202763183",
+          "version": null
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "SwiftIP",
         "repositoryURL": "https://github.com/Samasaur1/SwiftIP",
         "state": {
-          "branch": null,
-          "revision": "e1e8a43bd3020f1002c2680ae91056e6d81b647e",
-          "version": "2.2.0"
+          "branch": "fix-linux",
+          "revision": "0fb20b38f3edb9f77ce31c76ba3ba7c112eed08c",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Samasaur1/SwiftIP", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.2.0"),
-        .package(url: "https://github.com/httpswift/swifter", .exact("1.4.5")),
+        .package(url: "https://github.com/Samasaur1/swifter", .branch("simpleswiftserver-version")),
     ],
     targets: [
         .target(name: "SimpleSwiftServer", dependencies: ["ArgumentParser", "SwiftIP", "Swifter"]),

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .executable(name: "server", targets: ["SimpleSwiftServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Samasaur1/SwiftIP", .branch("fix-linux")),
+        .package(url: "https://github.com/Samasaur1/SwiftIP", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.2.0"),
         .package(url: "https://github.com/httpswift/swifter", .exact("1.4.5")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .executable(name: "server", targets: ["SimpleSwiftServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Samasaur1/SwiftIP", from: "2.0.0"),
+        .package(url: "https://github.com/Samasaur1/SwiftIP", .branch("fix-linux")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.2.0"),
         .package(url: "https://github.com/httpswift/swifter", .exact("1.4.5")),
     ],

--- a/Sources/SimpleSwiftServer/main.swift
+++ b/Sources/SimpleSwiftServer/main.swift
@@ -1,6 +1,6 @@
 import Swifter
 import Dispatch
-import Foundation.NSFileManager
+import Foundation
 import SwiftIP
 import ArgumentParser
 

--- a/Sources/SimpleSwiftServer/main.swift
+++ b/Sources/SimpleSwiftServer/main.swift
@@ -70,7 +70,7 @@ struct Server: ParsableCommand {
                     return .notFound
                 }
                 r.params[f.key] = f.value.removingPercentEncoding
-                return shareFilesFromDirectory(path)(r)
+                return shareFilesFromDirectory(self.path)(r)
             }
             server["/"] = { _ in
                 return .movedTemporarily("web/")

--- a/swifter.patch
+++ b/swifter.patch
@@ -1,0 +1,30 @@
+diff --git a/Sources/Socket+File.swift b/Sources/Socket+File.swift
+index 81f0c48..ff4b57f 100644
+--- a/Sources/Socket+File.swift
++++ b/Sources/Socket+File.swift
+@@ -19,15 +19,19 @@ import Foundation
+             }
+             var writeCounter = 0
+             while writeCounter < readResult {
+-                #if os(Linux)
+-                    let writeResult = send(target, &buffer + writeCounter, readResult - writeCounter, Int32(MSG_NOSIGNAL))
+-                #else
+-                    let writeResult = write(target, &buffer + writeCounter, readResult - writeCounter)
+-                #endif
++                let writeResult = buffer.withUnsafeBytes { (ptr) -> Int in
++                    let start = ptr.baseAddress! + writeCounter
++                    let len = readResult - writeCounter
++#if os(Linux)
++                    return send(target, start, len, Int32(MSG_NOSIGNAL))
++#else
++                    return write(target, start, len)
++#endif
++                }
+                 guard writeResult > 0 else {
+                     return Int32(writeResult)
+                 }
+-                writeCounter = writeCounter + writeResult
++                writeCounter += writeResult
+             }
+         }
+     }


### PR DESCRIPTION
Earlier today, I tried to build on a Linux machine (clang reports the target triple as `x86_64-unknown-linux-gnu`), and SimpleSwiftServer failed to build. I was able to track down all the bugs and get it building, and they are as follows:

1. [SwiftIP](https://github.com/Samasaur1/SwiftIP) was not building. I have opened a PR (Samasaur1/SwiftIP#11) to fix the problems in that project.
2. You can't import `Foundation.NSFileManager` on Linux since there is no NSFileManager. Since we were only limiting this import to try to optimize the macOS build, I've removed it (I doubt it was having much of an impact and the simplicity of not having conditional compilation is a priority over any slight reduction in macOS binary size)
3. The version of [Swifter](https://github.com/httpswift/swifter) that we are using, 1.4.5, did not build successfully. I was able to patch this to make this project compile, but I'm not sure how to publish this "fix" (since I cherry-picked changes from Swifter's stable branch)

Worth noting this build was with the following version of Swift:
```bash
$ swiftc --version
Swift version 5.5.1 (swift-5.5.1-RELEASE)
Target: x86_64-unknown-linux-gnu
```